### PR TITLE
Document current behavior of subsetting S3-hosted Hubble FITS files using AstroPy

### DIFF
--- a/notebooks/fornaxutils.py
+++ b/notebooks/fornaxutils.py
@@ -1,0 +1,134 @@
+"""Helper functions and classes to support the `fornax-s3-subsets` project.
+
+Author: Geert Barentsen
+"""
+import functools
+import time
+
+from astropy.table import Table
+from fsspec.implementations.http import HTTPFile
+from s3fs import S3File
+
+
+class NetworkProfiler:
+    """Profiling tool to monitor byte-range requests made by fsspec.
+
+    This class monkey-patches the fsspec-provided `HTTPFile._fetch_range()`
+    and `S3File._fetch_range()` methods to collect and display statistics
+    on the byte-range GET requests executed by these objects.  This enables
+    the exact network I/O behavior of tools using fsspec to be explored.
+
+    Example
+    -------
+    >>> with NetworkProfiler() as profiler:
+    >>>     with s3fs.open(s3_uri, mode="rb", block_size=50, cache_type="block") as fh:
+    >>>         fh.seek(100)
+    >>>         fh.read(80)
+    >>>     profiler.summary()
+    """
+
+    def __init__(self, verbose=True):
+        self.verbose = verbose
+        self._requests = []
+
+    def reset(self):
+        self._requests = []
+
+    def __enter__(self):
+        self.reset()
+
+        if not hasattr(self, "_old_httpfile_method"):
+            self._old_httpfile_method = HTTPFile._fetch_range
+        HTTPFile._fetch_range = self.get_wrapper(HTTPFile._fetch_range)
+
+        if not hasattr(self, "_old_s3file_method"):
+            self._old_s3file_method = S3File._fetch_range
+        S3File._fetch_range = self.get_wrapper(S3File._fetch_range)
+
+        return self
+
+    def __exit__(self, exc_type=None, exc_value=None, exc_tb=None):
+        HTTPFile._fetch_range = self._old_httpfile_method
+        S3File._fetch_range = self._old_s3file_method
+
+    def print(self, msg, end=None, color="\u001b[1m\u001b[31;1m"):
+        reset = "\u001b[0m"
+        print(f"{color}{msg}{reset}", end=end)
+
+    def summary(self):
+        self.print(
+            f"Summary: fetched {self.bytes_transferred()} "
+            f"bytes ({self.bytes_transferred()/(1024*1024):.2f} MB) "
+            f"in {self.time_elapsed():.2f} s ({self.throughput():.2f} MB/s) "
+            f"using {self.requests()} requests."
+        )
+
+    def log(self, byte_start, byte_end, time_elapsed):
+        """Register a byte-range requests."""
+        self._requests.append((byte_start, byte_end, time_elapsed))
+
+    def bytes_transferred(self) -> int:
+        """Total number of bytes fetched."""
+        return sum([req[1] - req[0] for req in self._requests])
+
+    def time_elapsed(self) -> float:
+        """Total time elapsed during network I/O in seconds."""
+        return sum([req[2] for req in self._requests])
+
+    def throughput(self) -> float:
+        """Returns the throughput in MB/s."""
+        return _compute_throughput(self.bytes_transferred(), self.time_elapsed())
+
+    def requests(self) -> int:
+        """Total number of GET byte-range requests made."""
+        return len(self._requests)
+
+    def get_wrapper(self, func):
+        """Wrapper intended to monkey-patch the `_fetch_range` methods in fsspec."""
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            obj, start, end = args
+            time_start = time.perf_counter()
+            result = func(*args, **kwargs)
+            time_elapsed = time.perf_counter() - time_start
+            if self.verbose:
+                if not self._requests:
+                    self.print(f"Retrieving {obj.path}")
+                throughput = _compute_throughput(end - start, time_elapsed)
+                self.print(f"GET bytes {start}-{end} " f"({throughput:.2f} MB/s)")
+            self.log(start, end, time_elapsed)
+            return result
+
+        return wrapper
+
+
+def _compute_throughput(bytes_transferred, time_elapsed) -> float:
+    if time_elapsed <= 0:
+        return float("inf")
+    return bytes_transferred / (time_elapsed * 1024 * 1024)
+
+
+def byte_layout_table(hdulist) -> Table:
+    """Returns the byte layout of a fits file as an AstroPy table."""
+    info = [hdu.fileinfo() for hdu in hdulist]
+    tbl = Table(info)
+    tbl.add_column(range(len(tbl)), name="HDU", index=0)
+    tbl["datEnd"] = tbl["datLoc"] + tbl["datSpan"]
+    tbl["size"] = (tbl["datEnd"] - tbl["hdrLoc"]) / (1024 * 1024)
+    tbl.keep_columns(["HDU", "hdrLoc", "datLoc", "datEnd", "size"])
+    for col in ["hdrLoc", "datLoc", "datEnd"]:
+        tbl[col].unit = "bytes"
+    tbl["size"].unit = "MB"
+    return tbl
+
+
+def print_byte_layout(hdulist) -> str:
+    """Prints the byte layout of a FITS file."""
+    tbl = byte_layout_table(hdulist)
+    result = ""
+    result += "HDU       hdrLoc      dataLoc  size\n"
+    result += "           bytes        bytes    MB\n"
+    for row in tbl:
+        result += f"{row['HDU']: 3d} {row['hdrLoc']: 12d} {row['datLoc']: 12d} {row['size']:>5.0f}\n"
+    print(result)

--- a/notebooks/hubble-cloud-subsetting-baseline.ipynb
+++ b/notebooks/hubble-cloud-subsetting-baseline.ipynb
@@ -1,0 +1,443 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c85dbd6f-3b45-4f51-b6ba-62707193d807",
+   "metadata": {},
+   "source": [
+    "# How to subset cloud-hosted Hubble FITS files using AstroPy?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb509085-9d20-4fec-915c-d1c8ee6f4a2e",
+   "metadata": {},
+   "source": [
+    "*Prepared by Geert Barentsen, last updated on March 17, 2022.*\n",
+    "\n",
+    "As part of the Fornax project, we aim to identify what changes to the FITS format and/or FITS libraries are required to enable astronomers to analyze cloud-hosted FITS files in a seamless and efficient way.  To help inform our decision making, this notebook explores how a Hubble Space Telescope image hosted in AWS S3 can best be analyzed using Python tools that exist today.\n",
+    "\n",
+    "## Goals\n",
+    "\n",
+    "This notebook aims to address three questions:\n",
+    "* How can we load S3-hosted FITS files using existing Python tools, specifically AstroPy?\n",
+    "* What is the current behavior of these tools?\n",
+    "* How can we improve the performance?\n",
+    "\n",
+    "The notebook will start by focusing on the problem of extracting a single Header Data Unit (HDU) from a large cloud-hosted FITS file.  This will be followed by a discussion on slicing data from a single HDU."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5aed2aa3-ad57-4687-9b10-c5ebb82b5474",
+   "metadata": {},
+   "source": [
+    "## 1. Benchmark data set\n",
+    "\n",
+    "For demonstration purposes, we selected a single 214 MB FITS file containing an HST/ACS image obtained as part of the *COSMOS 2-Degree ACS Survey* near coordinates (ra, dec) = (150.421375, 2.422383).  I selected Hubble data because it is easy to interpret and readily available on S3.  Everything in this notebook should apply to FITS files from any project however.\n",
+    "\n",
+    "For simplicity, we will assume that the user has already discovered the data set (e.g. using astroquery) and has obtained the following file URIs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7c5fed9-3faf-4a53-8772-b8a3393209f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HTTP URL of the FITS file at MAST\n",
+    "http_uri = \"https://mast.stsci.edu/api/v0.1/Download/file/?uri=mast:HST/product/j8pu0y010_drc.fits\"\n",
+    "\n",
+    "# AWS S3 URI of the same FITS file\n",
+    "s3_bucket = \"stpubdata\"\n",
+    "s3_key = \"hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits\"\n",
+    "s3_uri = f\"s3://{s3_bucket}/{s3_key}\"\n",
+    "\n",
+    "# Location of the data on local disk\n",
+    "local_path = \"/tmp/j8pu0y010_drc.fits\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0dd1687-28c2-4123-9bc0-0194c67b510e",
+   "metadata": {},
+   "source": [
+    "We will use the following Python imports below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5ab6877-1ec2-4ae1-a5a5-5940d3b9452d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from astropy.io import fits\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "# boto3 is the official AWS SDK for Python\n",
+    "import boto3\n",
+    "from botocore import UNSIGNED\n",
+    "from botocore.config import Config"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf168e9e-49c5-4a64-8035-c2eb72bbcfa9",
+   "metadata": {},
+   "source": [
+    "## 2. Baseline benchmark: downloading the entire file prior to opening\n",
+    "\n",
+    "At present, users can already pass HTTP urls to `astropy.io.fits.open(url)`.  AstroPy will recognize the url and download the entire file to the local filesystem before opening the file.\n",
+    "\n",
+    "AstroPy can conceivably be modified to adopt the same behavior for S3 URIs.  We will benchmark that behavior here by downloading the file using the AWS `boto3` library and subsequently opening the file using AstroPy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14ab59c0-7f8e-493a-97b6-75910eff2046",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# How long does it take to download the file?\n",
+    "s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))\n",
+    "s3.download_file(s3_bucket, s3_key, local_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "464834c3-1beb-469f-8b3f-d1cb5a98ddb0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# How much data did we download?\n",
+    "size = os.path.getsize(local_path) / (1024*1024)\n",
+    "print(f\"Downloaded {size:.0f} MB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33c3b44c-4e80-4922-844e-47a6d7495559",
+   "metadata": {},
+   "source": [
+    "Having downloaded the FITS file, it is trivial to open the file using AstroPy and plot a subset contained in HDU #1:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32ed8646-6bde-4dae-adc1-a805ef806481",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot a subset of the image contained in HDU 1\n",
+    "def plot_subset(hdulist):\n",
+    "    plt.imshow(hdulist[1].data[1600:1950, 2000:2250], vmin=0., vmax=0.1);\n",
+    "\n",
+    "hdulist = fits.open(local_path)\n",
+    "plot_subset(hdulist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a243ad65-50cc-4a77-9608-4590252b07f0",
+   "metadata": {},
+   "source": [
+    "## 3. Can we avoid downloading the entire file?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50d82961-b1b7-4ac3-aebd-d4c2e3a764cf",
+   "metadata": {},
+   "source": [
+    "The baseline benchmark is inefficient because the entire file was downloaded, which is unnecessary because we only plotted data from HDU #1.  Using `hdulist.info()` we can observe that the FITS file contains three additional large HDU's which we did not require:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eefb7028-18aa-4036-b1b8-ac3d6b53091c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdulist.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8922d596-9081-4579-a2ec-2169f8099419",
+   "metadata": {},
+   "source": [
+    "How much unnecessary data did we download?  Let's have a look at the byte structure of the FITS file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd32c354-1e53-4d8e-8c07-b0212e526a41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fornaxutils import print_byte_layout  # custom function defined in fornax.py\n",
+    "print_byte_layout(hdulist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "095821a3-4ecc-48da-86e8-01f3b313d638",
+   "metadata": {},
+   "source": [
+    "The table above shows that HDU #1 is 71 MB in size.  We can improve on the baseline benchmark by a factor ~3 by downloading this 71 MB section rather than the entire 214 MB file.  The table also shows the byte positions of the header (`hdrLoc`) and data section (`dataLoc`) of each HDU for future reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f05c7527-7cfc-432c-af73-011649bf9e57",
+   "metadata": {},
+   "source": [
+    "## 4. How to download a single HDU using AstroPy?\n",
+    "\n",
+    "For local files, AstroPy supports reading only the required HDUs via the `lazy_load_hdus` configuration parameter provided by [astropy.io.fits.open](https://docs.astropy.org/en/stable/io/fits/api/files.html#astropy.io.fits.open).  This mode is enabled by default and prevents AstroPy from loading HDU data into memory until it is required by the user.\n",
+    "\n",
+    "Specifically:\n",
+    "* The header of a HDU is only read into memory once `HDUList.__getitem__()` is called for that HDU.\n",
+    "* The data of a HDU is only read once the `.data` property of an HDU object is accessed (i.e., `.data` is implemented using the `@lazyproperty` decorator).\n",
+    "\n",
+    "\n",
+    "AstroPy implements this feature using the ability of the Python file object to read sub-sections of data using standard OS random file access operations.  For example, we can read a single header keyword from a local file as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85fc9371-6065-4a32-b92d-b2b4c558125c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = open(local_path)\n",
+    "f.seek(560) # move to byte position 560\n",
+    "f.read(80)  # read 80 bytes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a59b3483-19f4-4e22-a9c4-afd7e48b6b48",
+   "metadata": {},
+   "source": [
+    "Historically such random access file operations could only be used on local files.  In recent years, identical file object APIs have been created to enable seamless random access to remote file systems (including AWS S3, Google Cloud Storage, Azure Blob Storage, etc). These APIs have been grouped in the [fsspec project](https://filesystem-spec.readthedocs.io/en/latest/) which has its roots within the [Dask project](https://dask.org/).\n",
+    "\n",
+    "For example, we can efficiently read the same bytes from the FITS file using [s3fs](https://s3fs.readthedocs.io/en/latest/), which is the fsspec-based package to access data from AWS s3:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d95fef05-f41d-4841-a741-fa75afdebad6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from s3fs import S3FileSystem\n",
+    "\n",
+    "s3fs = S3FileSystem(anon=True)\n",
+    "with s3fs.open(s3_uri, mode=\"rb\") as fh:\n",
+    "    fh.seek(560)\n",
+    "    print(fh.read(79))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a38a2aa-b6fe-4eca-84b9-0252ba45d2ae",
+   "metadata": {},
+   "source": [
+    "Behind the scenes, `s3fs` uses the AWS SDK to fetch data using byte-range GET requests.  To observe the exact behavior I created a custom `NetworkProfiler` tool which monkey-patches fsspec to reveal the data transfer behavior (shown as red text):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffde3e09-532f-4813-829c-1d3086877c95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fornaxutils import NetworkProfiler   # custom class defined in fornaxutils.py\n",
+    "\n",
+    "with NetworkProfiler() as profiler:\n",
+    "    with s3fs.open(s3_uri, mode=\"rb\", block_size=80, cache_type=\"block\") as fh:\n",
+    "        fh.seek(560)\n",
+    "        fh.read(79)\n",
+    "    profiler.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62e94746-34ea-4259-b42e-8b5749013d21",
+   "metadata": {},
+   "source": [
+    "**Important**: the `block_size` and `cache_type` parameters passed to fsspec's `open()` function play a critical role in determining the performance.  These parameters control the size and frequency of the underlying GET requests that will be made to the remote server, similar to the way in which an operating system's *page size* impacts the efficency of swapping data between disk and memory.  The ideal values of these settings will depend on the use case, the network latency, and the server throughput.\n",
+    "\n",
+    "Note that we can access files exposed by the MAST HTTP server in the same way by substituting `S3FileSystem` with `HTTPFileSystem`. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "506b54f3-6321-49ed-84ef-3a3b0d0a1a92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fsspec.implementations.http import HTTPFileSystem\n",
+    "\n",
+    "with NetworkProfiler() as profiler:\n",
+    "    httpfs = HTTPFileSystem()\n",
+    "    with httpfs.open(http_uri, mode='rb', block_size=80, cache_type=\"block\") as fh:\n",
+    "        fh.seek(560)\n",
+    "        fh.read(79)\n",
+    "    profiler.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f99ada83-926a-4042-bf26-6d3489d9328d",
+   "metadata": {},
+   "source": [
+    "Other available options offered by fsspec include `GCSFileSystem` (Google Cloud), `AzureBlobFileSystem`, `HadoopFileSystem`, `FTPFileSystem`, `LocalFileSystem`, and many more."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f892548f-b7d3-4750-a6db-ae33f98303f1",
+   "metadata": {},
+   "source": [
+    "## 5. Can AstroPy access a single HDU from S3 storage in this way?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6b12a18-cd71-4a75-b995-4d8ab3a172da",
+   "metadata": {},
+   "source": [
+    "Yes!  By passing the `S3File` object provided by `s3fs`, we can trick AstroPy into thinking that an S3-hosted file is stored locally and supports random access. For example, we can read the header of HDU #4 by transferring only a tiny fraction of the FITS file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "026bf1bd-0a0e-4056-99b6-83883697fc8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with NetworkProfiler() as profiler:\n",
+    "    s3fs = S3FileSystem(anon=True)\n",
+    "    with s3fs.open(s3_uri, mode=\"rb\", block_size=100_000, cache_type=\"block\") as fh:\n",
+    "        with fits.open(fh) as hdulist:\n",
+    "            hdr = hdulist[4].header\n",
+    "    profiler.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "939d667c-899a-465e-99bf-0f7d21262dd2",
+   "metadata": {},
+   "source": [
+    "Next, let's try accessing data by plotting the same cutout from HDU 1 as we did before:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac427117-7b64-4af3-88bc-686e5b0697b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with NetworkProfiler() as profiler:\n",
+    "    s3fs = S3FileSystem(anon=True)\n",
+    "    with s3fs.open(s3_uri, mode=\"rb\", block_size=25_000_000, cache_type=\"block\") as fh:\n",
+    "        with fits.open(fh) as hdulist:\n",
+    "            plot_subset(hdulist)\n",
+    "    profiler.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c12b668-2c15-4d65-82b7-dbf2cf4be8cf",
+   "metadata": {},
+   "source": [
+    "As expected, AstroPy is able to access the image stored in HDU #1 without requiring the other image extensions to be loaded (i.e., only ~71 MB was downloaded rather than 214 MB).  Unfortunately, AstroPy does load the entire data section of HDU #1 rather than downloading only the cutout."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "936d4cf6-60c1-4aca-9d28-1ca3b8befa18",
+   "metadata": {},
+   "source": [
+    "# 6. Can we slice the remote image data using AstroPy?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0614e93a-74ce-43f5-a782-a118f446984d",
+   "metadata": {},
+   "source": [
+    "We would like to limit the data transfer to the bytes needed to plot the cutout region, rather than downloading the entire image array for HDU #1 (71 MB), \n",
+    "\n",
+    "AstroPy supports reading slices of data via the [memory mapping mechanism](https://docs.astropy.org/en/stable/io/fits/index.html#working-with-large-files) and the [buffer protocol](https://docs.python.org/3/c-api/buffer.html). Specifically, as part of `astropy.io.fits.file._File.readarray()`, AstroPy initializes data arrays by passing a `mmap` object to the `buffer` parameter of `np.ndarray` as follows: \n",
+    "```python\n",
+    "return np.ndarray(shape=shape, dtype=dtype, offset=offset, buffer=self._mmap)\n",
+    "```\n",
+    "\n",
+    "By creating an array in this way, numpy slicing will be translated into file seek/read calls at runtime as needed.  Unfortunately this happens deep inside the Numpy C code (or perhaps even the OS kernel), which makes it difficult to plug the pure-Python file interfaces provided by fsspec into this mechanism.  The buffer protocol is a Python C API concept which cannot be implemented in pure Python. As a result, it seems unlikely that we can repurpose the buffer interface mechanism here.\n",
+    "\n",
+    "Rather than returning `np.ndarray(buffer=....)` we will have to figure out how AstroPy may be modified to return a custom array-like object which can translate slicing operations into s3fs-based seek/read calls as needed. It is likely that we may be able to borrow code or insights from the array objects provided by Dask or Xarray, but this needs further research."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "720f0d6b-5f34-412b-8d15-b354605d89d1",
+   "metadata": {},
+   "source": [
+    "## Conclusions\n",
+    "\n",
+    "1. By passing file-like objects created using the `fsspec/s3fs` library into `astropy.io.fits.open()`, we can already use standard AstroPy features to extract individual HDU extensions from cloud-hosted FITS files in an efficient way.  The header and data sections of HDUs are only transferred from S3 when needed thanks to the existing `lazy_load_hdus` feature of AstroPy. We can start documenting and advertising the use of `s3fs` with AstroPy in this way -- this strategy is already more efficient than downloading entire files for applications which require a single HDU from a large file.\n",
+    "\n",
+    "2. Extracting slices of data from a single HDU is not yet possible and will likely require modifications to AstroPy.  Specifically, we need to modify AstroPy's `_File.readarray()` method to return an array-like object that can translate slicing operations into S3 file seek/read calls on the fly.\n",
+    "\n",
+    "3. We may not gain much by creating a \"central directory\" of header information and byte offsets, because AstroPy is already smart about loading HDU header and data sections only when they are needed.\n",
+    "\n",
+    "\n",
+    "## Footnotes\n",
+    "\n",
+    "* The `fitsio` package is a popular alternative to AstroPy.  It is unlikely to work with `fsspec`-based libraries because it is implemented by wrapping the `cfitsio` library. In contrast, `astropy.io.fits` is pure Python with the exception of the compression algorithms.\n",
+    "* HDF5 v1.10.6 and later supports cloud-hosted files in a similar way by providing the [S3 Virtual File Driver](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_ROS3) (a role fulfilled by `s3fs` in our case).  Like AstroPy, it does not appear to support slicing arrays and it does not benefit from a central directory of metadata.\n",
+    "* The `zarr` Python library natively support slicing arrays hosted in cloud-hosted zarr files."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
As part of the Fornax project, we aim to identify what changes to the FITS format and/or FITS libraries are required to enable astronomers to analyze cloud-hosted FITS files in a seamless and efficient way.  To help inform our decision making, this notebook explores how a Hubble Space Telescope image hosted in AWS S3 can best be analyzed using Python tools that exist today.

Specifically, this PR adds a notebook which explores three questions:
1. How can we load S3-hosted Hubble FITS files using existing Python tools, specifically AstroPy?
2. What is the current behavior of these tools?
3. How can we improve the performance?